### PR TITLE
feat(infra): Mitigate latent legendary problems (DiskPressure, ENI, CoreDNS)

### DIFF
--- a/helm/ray/values.yaml
+++ b/helm/ray/values.yaml
@@ -94,6 +94,14 @@ cpuWorkers:
     limits:
       cpu: "4"
       memory: "8Gi"
+      
+  volumeMounts:
+    - name: ray-tmp
+      mountPath: /tmp/ray
+      
+  volumes:
+    - name: ray-tmp
+      emptyDir: {}
   
   # Node selector for CPU nodes
   nodeSelector:
@@ -191,6 +199,14 @@ gpuWorkers:
       cpu: "8"
       memory: "32Gi"
       nvidia.com/gpu: "1"
+      
+  volumeMounts:
+    - name: ray-tmp
+      mountPath: /tmp/ray
+      
+  volumes:
+    - name: ray-tmp
+      emptyDir: {}
   
   # Node selector for GPU nodes
   nodeSelector:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -293,6 +293,7 @@ resource "aws_eks_addon" "addons" {
   resolve_conflicts_on_create = try(each.value.resolve_conflicts_on_create, "OVERWRITE")
   resolve_conflicts_on_update = try(each.value.resolve_conflicts_on_update, "OVERWRITE")
   service_account_role_arn    = try(each.value.service_account_role_arn, null)
+  configuration_values        = try(each.value.configuration_values, null)
 
   depends_on = [
     aws_eks_node_group.cpu_workers,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,6 +79,7 @@ variable "eks_addons" {
     vpc-cni = {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
+      configuration_values        = "{\"env\":{\"ENABLE_PREFIX_DELEGATION\":\"true\"}}"
     }
     kube-proxy = {
       resolve_conflicts_on_create = "OVERWRITE"
@@ -87,6 +88,7 @@ variable "eks_addons" {
     coredns = {
       resolve_conflicts_on_create = "OVERWRITE"
       resolve_conflicts_on_update = "OVERWRITE"
+      configuration_values        = "{\"replicaCount\":4,\"resources\":{\"limits\":{\"cpu\":\"200m\",\"memory\":\"256Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"128Mi\"}}}"
     }
   }
 }


### PR DESCRIPTION
Mitigates three newly-discovered critical vulnerabilities: (1) Adds 'emptyDir' mounts for '/tmp/ray' to prevent Kubelet 'DiskPressure' mass-evictions, (2) Configures VPC CNI with 'ENABLE_PREFIX_DELEGATION=true' to prevent ENI IP exhaustion on GPU nodes, and (3) Scales 'coredns' with custom compute and replica counts to prevent DNS connection timeouts during Ray worker scale-up storms.