### PR TITLE
perf(ray): Mount GPU instance /tmp/ray spillage to Memory

### DIFF
--- a/helm/ray/values.yaml
+++ b/helm/ray/values.yaml
@@ -206,7 +206,8 @@ gpuWorkers:
       
   volumes:
     - name: ray-tmp
-      emptyDir: {}
+      emptyDir:
+        medium: Memory
   
   # Node selector for GPU nodes
   nodeSelector:


### PR DESCRIPTION
Optimizes Ray object spilling on GPU instances by backing the /tmp/ray emptyDir with memory (tmpfs), allowing spillage to occur at RAM speeds instead of EBS latency.