### PR TITLE
chore: remove duplicate .DS_Store entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ env/
 *.swp
 *.swo
 *~
-.DS_Store
 
 # Secrets
 *.pem


### PR DESCRIPTION
Fixes #55

## Changes
- Removed duplicate `.DS_Store` entry from line 55 (under `# IDE` section)
- Kept the entry under `# OS` section (line 78) as `.DS_Store` is an OS artifact

## Testing
- Verified only one `.DS_Store` entry remains in `.gitignore`
- No other changes made

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to track system files previously excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->